### PR TITLE
#2 - List a single todo by ID 

### DIFF
--- a/server/src/main/java/umm3601/Server.java
+++ b/server/src/main/java/umm3601/Server.java
@@ -51,6 +51,9 @@ public class Server {
     // List users, filtered using query parameters
     server.get("/api/users", userController::getUsers);
 
+    // Get specific todo
+    server.get("/api/todos/{id}", todoController::getTodo);
+
     // List todos, filtered using query parameters
     server.get("/api/todos", todoController::getTodos);
   }

--- a/server/src/main/java/umm3601/todo/TodoController.java
+++ b/server/src/main/java/umm3601/todo/TodoController.java
@@ -3,8 +3,8 @@
 package umm3601.todo;
 
 import io.javalin.http.Context;
-//import io.javalin.http.HttpStatus;
-//import io.javalin.http.NotFoundResponse;
+import io.javalin.http.HttpStatus;
+import io.javalin.http.NotFoundResponse;
 
 /**
  * Controller that manages requests for info about users.
@@ -24,6 +24,22 @@ public class TodoController {
    */
   public TodoController(TodoDatabase database) {
     this.database = database;
+  }
+
+  /**
+   * Get the single todo specified by the `id` parameter in the request.
+   *
+   * @param ctx a Javalin HTTP context
+   */
+  public void getTodo(Context ctx) {
+    String id = ctx.pathParam("id");
+    Todo todo = database.getTodo(id);
+    if (todo != null) {
+      ctx.json(todo);
+      ctx.status(HttpStatus.OK);
+    } else {
+      throw new NotFoundResponse("No todo with id " + id + " was found.");
+    }
   }
 
   /**

--- a/server/src/main/java/umm3601/todo/TodoDatabase.java
+++ b/server/src/main/java/umm3601/todo/TodoDatabase.java
@@ -34,6 +34,17 @@ public class TodoDatabase {
   }
 
   /**
+   * Get the single todo specified by the given ID. Return `null` if there is no
+   * todo with that ID.
+   *
+   * @param id the ID of the desired todo
+   * @return the todo with the given ID, or null if there is no todo with that ID
+   */
+  public Todo getTodo(String id) {
+    return Arrays.stream(allTodos).filter(x -> x._id.equals(id)).findFirst().orElse(null);
+  }
+
+  /**
    * Get an array of all the todos satisfying the queries in the params.
    *
    * @param queryParams map of key-value paiAdded mers for the query

--- a/server/src/test/java/umm3601/todo/TodoControllerSpec.java
+++ b/server/src/test/java/umm3601/todo/TodoControllerSpec.java
@@ -15,14 +15,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-//import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assertions;
 //import org.junit.jupiter.api.BeforeEach;
 //import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 //import io.javalin.http.BadRequestResponse;
-//import io.javalin.http.HttpStatus;
-//import io.javalin.http.NotFoundResponse;
+import io.javalin.http.HttpStatus;
+import io.javalin.http.NotFoundResponse;
 
 
 /**
@@ -143,6 +143,32 @@ public class TodoControllerSpec {
       assertEquals("software design", todo.category);
     }
     assertEquals(10, argument.getValue().length);
+  }
+
+  @Test
+  public void canGetTodosWithSpecifiedId() throws IOException {
+    String id = "58895985140cca06def60d82";
+    Todo todo = db.getTodo(id);
+
+    when(ctx.pathParam("id")).thenReturn(id);
+
+    todoController.getTodo(ctx);
+
+    verify(ctx).json(todo);
+    verify(ctx).status(HttpStatus.OK);
+    assertEquals("Fry", todo.owner);
+    assertEquals("video games", todo.category);
+    assertEquals(false, todo.status);
+
+  }
+
+  @Test
+  public void respondsAppropriatelyToRequestForNonexistentId() throws IOException {
+    when(ctx.pathParam("id")).thenReturn(null);
+    Throwable exception = Assertions.assertThrows(NotFoundResponse.class, () -> {
+      todoController.getTodo(ctx);
+    });
+    assertEquals("No todo with id " + null + " was found.", exception.getMessage());
   }
 
 }


### PR DESCRIPTION
The server can now handle requests to get Todos by their ID, and send a 404 NotFoundResponse if a Todo with the given ID does not exist.