### PR TITLE
#4 - Support filtering todos by their status

### DIFF
--- a/server/src/main/java/umm3601/todo/TodoDatabase.java
+++ b/server/src/main/java/umm3601/todo/TodoDatabase.java
@@ -68,11 +68,11 @@ public class TodoDatabase {
     if (queryParams.containsKey("status")) {
       String statusParam = queryParams.get("status").get(0);
       boolean targetStatus = false;
-      if (statusParam.contains("complete")) {
+      if (statusParam.equals("complete")) {
         targetStatus = true;
       }
       // Throw BadRequestResponse if the requested status does not match a boolean value (complete/incomplete)
-      if (!statusParam.contains("incomplete")) {
+      else if (!statusParam.contains("incomplete")) {
         throw new BadRequestResponse("Specified status '" + statusParam + "' can't be interpreted as a boolean");
       }
       filteredTodos = filterTodosByStatus(filteredTodos, targetStatus);
@@ -114,8 +114,8 @@ public class TodoDatabase {
    *         status
    *
    */
-  public Todo[] filterTodosByStatus(Todo[] todos, Boolean targetStatus) {
-    return Arrays.stream(todos).filter(x -> x.status = targetStatus).toArray(Todo[]::new);
+  public Todo[] filterTodosByStatus(Todo[] todos, boolean targetStatus) {
+    return Arrays.stream(todos).filter(x -> x.status == targetStatus).toArray(Todo[]::new);
   }
 
 }

--- a/server/src/main/java/umm3601/todo/TodoDatabase.java
+++ b/server/src/main/java/umm3601/todo/TodoDatabase.java
@@ -70,9 +70,8 @@ public class TodoDatabase {
       boolean targetStatus = false;
       if (statusParam.equals("complete")) {
         targetStatus = true;
-      }
-      // Throw BadRequestResponse if the requested status does not match a boolean value (complete/incomplete)
-      else if (!statusParam.contains("incomplete")) {
+      } else if (!statusParam.contains("incomplete")) {
+        // Throw BadRequestResponse if the requested status does not match a boolean value (complete/incomplete)
         throw new BadRequestResponse("Specified status '" + statusParam + "' can't be interpreted as a boolean");
       }
       filteredTodos = filterTodosByStatus(filteredTodos, targetStatus);

--- a/server/src/main/java/umm3601/todo/TodoDatabase.java
+++ b/server/src/main/java/umm3601/todo/TodoDatabase.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-//import io.javalin.http.BadRequestResponse;
+import io.javalin.http.BadRequestResponse;
 
 /**
  * A fake "database" of todo info
@@ -47,7 +47,7 @@ public class TodoDatabase {
   /**
    * Get an array of all the todos satisfying the queries in the params.
    *
-   * @param queryParams map of key-value paiAdded mers for the query
+   * @param queryParams map of key-value pairs for the query
    * @return an array of all the users matching the given criteria
    */
   public Todo[] listTodos(Map<String, List<String>> queryParams) {
@@ -64,6 +64,19 @@ public class TodoDatabase {
       filteredTodos = filterTodosByCategory(filteredTodos, targetCategory);
     }
     // Process other query parameters here...
+    // Filter status if defined
+    if (queryParams.containsKey("status")) {
+      String statusParam = queryParams.get("status").get(0);
+      boolean targetStatus = false;
+      if (statusParam.contains("complete")) {
+        targetStatus = true;
+      }
+      // Throw BadRequestResponse if the requested status does not match a boolean value (complete/incomplete)
+      if (!statusParam.contains("incomplete")) {
+        throw new BadRequestResponse("Specified status '" + statusParam + "' can't be interpreted as a boolean");
+      }
+      filteredTodos = filterTodosByStatus(filteredTodos, targetStatus);
+    }
 
     return filteredTodos;
   }
@@ -90,6 +103,19 @@ public class TodoDatabase {
    */
   public Todo[] filterTodosByCategory(Todo[] todos, String targetCategory) {
     return Arrays.stream(todos).filter(x -> x.category.equals(targetCategory)).toArray(Todo[]::new);
+  }
+
+  /**
+   * Get an array of all the todos having the target status.
+   *
+   * @param todos     the list of todos to filter by status
+   * @param targetStatus the target status to look for
+   * @return an array of all the todos from the given list that have the target
+   *         status
+   *
+   */
+  public Todo[] filterTodosByStatus(Todo[] todos, Boolean targetStatus) {
+    return Arrays.stream(todos).filter(x -> x.status = targetStatus).toArray(Todo[]::new);
   }
 
 }


### PR DESCRIPTION
Functionality and tests were implemented into TodoDatabase and TodoControllerSpec respectively to provide the server with functionality to retrieve Todos by their status. "complete" as a parameter will correspond to the boolean true, and "incomplete" as a parameter will correspond to the boolean false. Any other inputs for this parameter will throw a BadRequestResponse.